### PR TITLE
removing base package

### DIFF
--- a/appspec.json
+++ b/appspec.json
@@ -76,9 +76,6 @@
         "name": "rlang"
       },
       {
-        "name": "utils"
-      },
-      {
         "name": "keyring"
       }
     ]


### PR DESCRIPTION
Hi Bruno,
I removed the library "utils" from the appspec file. All the libraries that are listed in the appspec file will be installed in the docker of the App. In R, if trying to install a base library (as is utils), one gets a warning that this is not possible. For some odd reason in the dockers build in MoveApps, this leads to an error that crashes the building process of the App. We'll have to fix this at some point in some way, but for now, excluding them from the list works best. I do not know which library is base and which not, and I mostly do not remember to check before submitting an App, so I now and again also run in to this issue. 
Given that it is not yet written in the documentation, there is no way you could have known. I'll look now for a place to include it.
No need to make a new release, just when you submit the next version at some point, this library will already be removed and I do not have to remember to remove it in the building process as I did today. 
Thank you for all your great contributions!
Anne