### PR TITLE
update to input type secret

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,7 @@
 # development settings
 CONFIGURATION_FILE=./app-configuration.json
 PRINT_CONFIGURATION=yes
+MASK_SETTING_IDS=pwd
 SOURCE_FILE=./data/raw/input_sdk_testing.rds
 OUTPUT_FILE=./data/output/output.rds
 ERROR_FILE=./data/output/error.log

--- a/app-configuration.json
+++ b/app-configuration.json
@@ -1,5 +1,5 @@
 {
-  "usr": "secret",
+  "usr": "",
   "pwd": "secret",
   "merging_rule": "latest",
   "store_acc_track_info": false,

--- a/app-configuration.json
+++ b/app-configuration.json
@@ -1,6 +1,6 @@
 {
-  "usr": "",
-  "pwd": "",
+  "usr": null,
+  "pwd": "your_pw",
   "merging_rule": "latest",
   "store_acc_track_info": false,
   "acc_timefilter": 0

--- a/app-configuration.json
+++ b/app-configuration.json
@@ -1,6 +1,6 @@
 {
-  "usr": null,
-  "pwd": "your_pw",
+  "usr": "secret",
+  "pwd": "secret",
   "merging_rule": "latest",
   "store_acc_track_info": false,
   "acc_timefilter": 0

--- a/appspec.json
+++ b/appspec.json
@@ -4,15 +4,15 @@
       "id": "usr",
       "name": "Movebank username",
       "description": "Type-in the username of your Movebank account",
-      "defaultValue": "",
+      "defaultValue": null,
       "type": "STRING"
     },
     {
       "id": "pwd",
       "name": "Movebank password",
       "description": "Type-in the password of your Movebank account",
-      "defaultValue": "",
-      "type": "STRING"
+      "defaultValue": null,
+      "type": "SECRET"
     },
     {
       "id": "merging_rule",


### PR DESCRIPTION
Hi @bcaneco, 
we have included a new input type "SECRET" for passwords, api-keys, etc. I made the necessary changes to include this new setting into your App. Using the input type secret, the passwords will not be printed as plain text in the logs and not be passed in when sharing a Workflow. 
We are currently working on creating a document that will contain all settings of all Apps of a Workflow. Given that this document can be easily shared and also appended to publications, it is for us of great importance that no sensitive information is contained.
Therefore we would like to ask you if you could resubmit your App with these changes as soon as you can. Once all Apps that contain plain text passwords are rebuilt, we can implement the creation of the settings summary document.
Thank you very much!
Best, Anne